### PR TITLE
Cleanup Win64 action

### DIFF
--- a/.github/workflows/win-prove6.yml
+++ b/.github/workflows/win-prove6.yml
@@ -25,9 +25,8 @@ jobs:
       - uses: Raku/setup-raku@v1
       - name: Install Dependencies
         run: |
-            choco install rakudostar
-            zef --exclude="z, curl" install --debug --/test --test-depends --deps-only .
+            zef --exclude='curl:ver<4>:from<native>' install --debug --/test --test-depends --deps-only .
       - name: Run Tests
-        run: prove6
+        run: prove6 -I.
       - name: Install
         run: zef install . 


### PR DESCRIPTION
* Don't install rakudostar - this image already has the latest raku in it
* Exclude curl - need specific version to skip
* Running prove6 in an uninstalled directory needs the include path set